### PR TITLE
Fix bug when adding customer key

### DIFF
--- a/fuelsdk.gemspec
+++ b/fuelsdk.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "savon"
   spec.add_dependency "json"
-  spec.add_dependency "jwt", "~> 0.1.6"
+  spec.add_dependency "jwt"
   spec.add_dependency "activesupport", "~> 3.2.8"
 end

--- a/fuelsdk.gemspec
+++ b/fuelsdk.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-rspec"
 
   spec.add_dependency "savon"
-  spec.add_dependency "json", "~> 1.7.0"
+  spec.add_dependency "json"
   spec.add_dependency "jwt", "~> 0.1.6"
   spec.add_dependency "activesupport", "~> 3.2.8"
 end

--- a/lib/fuelsdk/objects.rb
+++ b/lib/fuelsdk/objects.rb
@@ -199,26 +199,24 @@ module FuelSDK
       end
 
       def post
-        add_customer_key self.properties
+        ensure_customer_key self.properties
         super
       end
 
       def patch
-        add_customer_key self.properties
+        ensure_customer_key self.properties
         super
       end
 
       def delete
-        add_customer_key self.properties
+        ensure_customer_key self.properties
         super
       end
 
       private
-        def add_customer_key data
-          data.each do |d|
-            next if d.include? 'CustomerKey'
-            d['CustomerKey'] = customer_key
-          end
+        def ensure_customer_key data
+          return if data.has_key?('CustomerKey')
+          data['CustomerKey'] = customer_key
         end
 
         def retrieve_required


### PR DESCRIPTION
The data passed into `Row#ensure_customer_key`, which was renamed from `Row#add_customer_key`, was a hash. The method should have been looking for a hash key. Instead, it was iterating through the keys and values using `#each`. The value `d` passed into the block was an array whose first element was a hash key and whose second element was a hash value. `d['CustomerKey']` threw an error. This PR fixes that.

The author of the bug fix also relaxed the version requirements for the json and jwt gems.
