### PR TITLE
Sandbox - additional optional configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ Add a require statement to reference the Fuel SDK's functionality:
 Next, create an instance of the Client class:
 > myClient = FuelSDK::Client.new {'client' => { 'id' => CLIENTID, 'secret' => SECRET }}
 
+https://developer.salesforce.com/docs/atlas.en-us.mc-getting-started.meta/mc-getting-started/requestToken.htm
+
+Note: Added new option to client initilizer 'refresh_token_url' (changes depending on ET environment) 
+> myClient = FuelSDK::Client.new { 'client' => {...}, 'refresh_token_url' => 'https://auth-test.exacttargetapis.com/v1/requestToken', 'defaultwsdl' => 'https://webservice.test.exacttarget.com/etframework.wsdl' }
+
+https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/getting_started_developers_and_the_exacttarget_api.htm
+
+Note: Added 'endpoint_service_url' accessor to Targeting to allow specifying different soap endpoint
+> myClient.endpoint_service_url = 'https://webservice.test.exacttarget.com/Service.asmx' # depending on ET instance
+
 Create an instance of the object type we want to work with:
 > list = FuelSDK::List.new
 

--- a/lib/fuelsdk/client.rb
+++ b/lib/fuelsdk/client.rb
@@ -39,7 +39,7 @@ module FuelSDK
 
   class Client
     attr_accessor :debug, :auth_token, :internal_token, :refresh_token,
-      :id, :secret, :signature
+      :id, :secret, :signature, :refresh_token_url
 
     include FuelSDK::Soap
     include FuelSDK::Rest
@@ -75,6 +75,9 @@ module FuelSDK
 
       self.jwt = params['jwt'] if params['jwt']
       self.refresh_token = params['refresh_token'] if params['refresh_token']
+      # https://developer.salesforce.com/docs/atlas.en-us.mc-getting-started.meta/mc-getting-started/requestToken.htm
+      # Allow different request token urls to be used to specify sandbox / production environment
+      self.refresh_token_url = params['refresh_token_url'] if params['refresh_token_url']
 
       self.wsdl = params["defaultwsdl"] if params["defaultwsdl"]
     end
@@ -106,7 +109,7 @@ module FuelSDK
       if (self.auth_token.nil? || force)
         clear_client!
         options =  request_token_options(request_token_data)
-        response = post("https://auth.exacttargetapis.com/v1/requestToken", options)
+        response = post(self.refresh_token_url || "https://auth.exacttargetapis.com/v1/requestToken", options)
         raise "Unable to refresh token: #{response['message']}" unless response.has_key?('accessToken')
 
         self.auth_token = response['accessToken']

--- a/lib/fuelsdk/client.rb
+++ b/lib/fuelsdk/client.rb
@@ -39,7 +39,7 @@ module FuelSDK
 
   class Client
     attr_accessor :debug, :auth_token, :internal_token, :refresh_token,
-      :id, :secret, :signature, :refresh_token_url
+      :id, :secret, :signature, :refresh_token_url, :targeting_endpoint
 
     include FuelSDK::Soap
     include FuelSDK::Rest
@@ -80,6 +80,7 @@ module FuelSDK
       self.refresh_token_url = params['refresh_token_url'] if params['refresh_token_url']
 
       self.wsdl = params["defaultwsdl"] if params["defaultwsdl"]
+      self.targeting_endpoint = params['targeting_endpoint'] if params['targeting_endpoint']
     end
 
     def request_token_data

--- a/lib/fuelsdk/client.rb
+++ b/lib/fuelsdk/client.rb
@@ -118,8 +118,9 @@ module FuelSDK
       end
     end
 
+    # Note: never force refresh, leave that to outside logic to update tokens after they expire
     def refresh!
-      refresh true
+      refresh
     end
 
     def AddSubscriberToList(email, ids, subscriber_key = nil)

--- a/lib/fuelsdk/targeting.rb
+++ b/lib/fuelsdk/targeting.rb
@@ -10,7 +10,7 @@ module FuelSDK::Targeting
   end
 
   def endpoint
-    @endpoint ||= determine_stack(@endpoint_service_url)
+    @endpoint ||= self.targeting_endpoint || determine_stack(@endpoint_service_url)
   end
 
   # https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/getting_started_developers_and_the_exacttarget_api.htm
@@ -20,14 +20,8 @@ module FuelSDK::Targeting
     options = {'params' => {'access_token' => self.auth_token}}
     response = get(endpoint_service_url || "https://www.exacttargetapis.com/platform/v1/endpoints/soap", options)
 
-    unless response.success?
-      # if unsuccessful, force refresh token and try with new token before raising exception
-      refresh!
-      options = {'params' => {'access_token' => self.auth_token}}
-      response = get(endpoint_service_url || "https://www.exacttargetapis.com/platform/v1/endpoints/soap", options)
-
-      raise "Unable to determine stack #{response.code}, #{response.body.inspect}" unless response.success?
-    end
+    raise "Unable to determine stack #{response.code}, #{response.body.inspect}" unless response.success?
+    self.targeting_endpoint = response['url']
     response['url']
   end
 end

--- a/lib/fuelsdk/targeting.rb
+++ b/lib/fuelsdk/targeting.rb
@@ -1,6 +1,7 @@
 module FuelSDK::Targeting
   attr_accessor :auth_token
   attr_accessor :endpoint
+  attr_accessor :endpoint_service_url
 
   include FuelSDK::HTTPRequest
 
@@ -9,13 +10,15 @@ module FuelSDK::Targeting
   end
 
   def endpoint
-    @endpoint ||= determine_stack
+    @endpoint ||= determine_stack(@endpoint_service_url)
   end
 
-  def determine_stack
+  # https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/getting_started_developers_and_the_exacttarget_api.htm
+  # Allow different endpoint url to be used between sandbox / production ET environment
+  def determine_stack(endpoint_service_url=nil)
     refresh unless self.auth_token
     options = {'params' => {'access_token' => self.auth_token}}
-    response = get("https://www.exacttargetapis.com/platform/v1/endpoints/soap", options)
+    response = get(endpoint_service_url || "https://www.exacttargetapis.com/platform/v1/endpoints/soap", options)
     raise 'Unable to determine stack' unless response.success?
     response['url']
   end

--- a/lib/fuelsdk/targeting.rb
+++ b/lib/fuelsdk/targeting.rb
@@ -19,7 +19,15 @@ module FuelSDK::Targeting
     refresh unless self.auth_token
     options = {'params' => {'access_token' => self.auth_token}}
     response = get(endpoint_service_url || "https://www.exacttargetapis.com/platform/v1/endpoints/soap", options)
-    raise 'Unable to determine stack' unless response.success?
+
+    unless response.success?
+      # if unsuccessful, force refresh token and try with new token before raising exception
+      refresh!
+      options = {'params' => {'access_token' => self.auth_token}}
+      response = get(endpoint_service_url || "https://www.exacttargetapis.com/platform/v1/endpoints/soap", options)
+
+      raise "Unable to determine stack #{response.code}, #{response.body.inspect}" unless response.success?
+    end
     response['url']
   end
 end

--- a/lib/fuelsdk/version.rb
+++ b/lib/fuelsdk/version.rb
@@ -1,3 +1,3 @@
 module FuelSDK
-  VERSION = "0.1.13"
+  VERSION = "0.1.14"
 end

--- a/lib/fuelsdk/version.rb
+++ b/lib/fuelsdk/version.rb
@@ -1,3 +1,3 @@
 module FuelSDK
-  VERSION = "0.1.10"
+  VERSION = "0.1.11"
 end

--- a/lib/fuelsdk/version.rb
+++ b/lib/fuelsdk/version.rb
@@ -1,3 +1,3 @@
 module FuelSDK
-  VERSION = "0.1.11"
+  VERSION = "0.1.12"
 end

--- a/lib/fuelsdk/version.rb
+++ b/lib/fuelsdk/version.rb
@@ -1,3 +1,3 @@
 module FuelSDK
-  VERSION = "0.1.12"
+  VERSION = "0.1.13"
 end


### PR DESCRIPTION
* Update fuelsdk to allow configuring different endpoint/token authorization paths depending on ET environment
* Allow 'refresh_token_url' to be specified upon client initialization
* Allow 'endpoint_service_url' to be specified after initializing client